### PR TITLE
96 frontend resolve short list bug

### DIFF
--- a/frontend/src/components/HomePage/ScanningHistoryTable.tsx
+++ b/frontend/src/components/HomePage/ScanningHistoryTable.tsx
@@ -12,7 +12,7 @@ function ScanningHistoryTable() {
       year: "numeric",
     }).format(new Date(dateValue));
   return (
-    <section className="lg:col-span-2 rounded-lg border border-(--color-primary) shadow-sm" aria-label="Nylig screeningaktivitet">
+    <section className="lg:col-span-2 lg:self-start rounded-lg border border-(--color-primary) shadow-sm" aria-label="Nylig screeningaktivitet">
 
         {/* Screening history header */}
         <header className="border-b border-(--color-primary) p-6 bg-(--color-light) rounded-t-lg ">

--- a/frontend/src/components/ScreeningPage/CandidateCard.tsx
+++ b/frontend/src/components/ScreeningPage/CandidateCard.tsx
@@ -9,6 +9,7 @@ type CandidateCardProps = {
 };
 
 function CandidateCard({ candidate, id }: CandidateCardProps) {
+  console.log(candidate)
   return (
     <div
       id={id + ""}
@@ -27,14 +28,8 @@ function CandidateCard({ candidate, id }: CandidateCardProps) {
           </div>
         </div>
 
-        {candidate.aml ? (
-          <Badge variant="secondary">
-            {"AML §" + candidate.aml}
-          </Badge>
-        
-        ) : (
-          ""
-        )}
+        {candidate.aml46 ? <Badge variant="secondary">{"AML §4.6"}</Badge> : ""}
+        {candidate.aml47 ? <Badge variant="secondary">{"AML §4.7"}</Badge> : ""}
       </div>
 
       <article className="flex justify-between">

--- a/frontend/src/components/ScreeningPage/CandidateOverview.tsx
+++ b/frontend/src/components/ScreeningPage/CandidateOverview.tsx
@@ -57,5 +57,6 @@ function CandidateOverview({ candidates }: { candidates: RankedCandidate[] }) {
       </footer>
     </section>
   );
+  
 }
 export default CandidateOverview;

--- a/frontend/src/components/ScreeningPage/CandidateSidebar.tsx
+++ b/frontend/src/components/ScreeningPage/CandidateSidebar.tsx
@@ -14,7 +14,7 @@ function CandidateSidbar({ candidates }: { candidates: RankedCandidate[] }) {
               className=" px-3 py-2 flex text-sm opacity-70 hover:opacity-100 uppercase"
             >
               <p>{candidate.candidateName}</p> 
-              {candidate.aml ? (<p className="mx-1">§</p>) : ("")} 
+              {(candidate.aml46 || candidate.aml47) ? (<p className="mx-1">§</p>) : ("")} 
             </a>
           ))}
         </article>

--- a/frontend/src/components/ScreeningPage/CandidateSidebar.tsx
+++ b/frontend/src/components/ScreeningPage/CandidateSidebar.tsx
@@ -7,7 +7,7 @@ function CandidateSidbar({ candidates }: { candidates: RankedCandidate[] }) {
       {candidates.some((c) => c.qualified) ? (
         <article className="flex flex-col">
           <h3 className="subsection-title sm:grid-">Kvalifiserte Kandidater</h3>
-          {candidates.map((candidate) => (
+          {candidates .filter((candidate) => candidate.qualified).map((candidate) => (
             <a
               key={candidate.candidateId}
               href={`#${candidate.candidateId}`}
@@ -27,7 +27,7 @@ function CandidateSidbar({ candidates }: { candidates: RankedCandidate[] }) {
       {candidates.some((c) => !c.qualified) ? (
         <article className="flex flex-col">
           <h3 className="subsection-title">Ikke-kvalifiserte Kandidater</h3>
-          {candidates.map((candidate) => (
+          {candidates .filter((candidate) => !candidate.qualified).map((candidate) => (
             <a
               key={candidate.candidateId}
               href={`#${candidate.candidateId}`}

--- a/frontend/src/components/ScreeningPage/CandidateSidebar.tsx
+++ b/frontend/src/components/ScreeningPage/CandidateSidebar.tsx
@@ -1,7 +1,7 @@
 import type { RankedCandidate } from "@/types/screening";
 function CandidateSidbar({ candidates }: { candidates: RankedCandidate[] }) {
   return (
-    <aside className="lg:sticky lg:top-10 lg:h-[90vh] lg:flex lg:flex-col lg:overflow-scroll sm:grid sm:grid-cols-2 sm:m-4">
+    <aside className="lg:sticky lg:top-10 lg:h-[90vh] lg:flex lg:flex-col lg:overflow-auto sm:grid sm:grid-cols-2 sm:m-4">
       <h2 className="my-4 text-xl font-bold sm:col-span-2">Oversikt</h2>
 
       {candidates.some((c) => c.qualified) ? (

--- a/frontend/src/components/newScreening/NewScreening.tsx
+++ b/frontend/src/components/newScreening/NewScreening.tsx
@@ -1,9 +1,9 @@
 import ErrorBox from "@/components/ErrorBox";
-import ProcessingStatusCard from "@/components/newScreening/ProcessingStatusCard";
+import ProcessingStatusCard from "@/components/NewScreening/ProcessingStatusCard";
 import type { JobDescriptionInput } from "@/validations/UploadJobDescriptionSchema";
-import ScreeningProgressSteps from "@/components/newScreening/ScreeningProgressSteps";
+import ScreeningProgressSteps from "@/components/NewScreening/ScreeningProgressSteps";
 import type { StepStatus } from "@/types/newScreeningTypes";
-import UploadJobDescriptionCard from "@/components/newScreening/UploadJobDescriptionCard";
+import UploadJobDescriptionCard from "@/components/NewScreening/UploadJobDescriptionCard";
 import HeaderSection from "../HeaderSection";
 
 type NewScreeningError = {

--- a/frontend/src/components/newScreening/UploadJobDescriptionCard.tsx
+++ b/frontend/src/components/newScreening/UploadJobDescriptionCard.tsx
@@ -36,7 +36,6 @@ type UploadJobDescriptionCardProps = {
 function UploadJobDescriptionCard({
   initialInput,
   showRetryLabel,
-  onCancel,
   onStartProcessing,
 }: UploadJobDescriptionCardProps) {
   const form = useForm<UploadJobDescriptionValues>({

--- a/frontend/src/components/newScreening/UploadJobDescriptionCard.tsx
+++ b/frontend/src/components/newScreening/UploadJobDescriptionCard.tsx
@@ -24,6 +24,7 @@ import { Field, FieldDescription, FieldError } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { Link } from "react-router";
 
 type UploadJobDescriptionCardProps = {
   initialInput: JobDescriptionInput | null;
@@ -44,16 +45,20 @@ function UploadJobDescriptionCard({
     shouldFocusError: true,
     defaultValues: {
       mode: initialInput?.mode ?? "pdf",
-      jobDescriptionFile: initialInput?.mode === "pdf" ? initialInput.file : undefined,
-      jobDescriptionText: initialInput?.mode === "text" ? initialInput.text : "",
+      jobDescriptionFile:
+        initialInput?.mode === "pdf" ? initialInput.file : undefined,
+      jobDescriptionText:
+        initialInput?.mode === "text" ? initialInput.text : "",
     },
   });
 
   useEffect(() => {
     form.reset({
       mode: initialInput?.mode ?? "pdf",
-      jobDescriptionFile: initialInput?.mode === "pdf" ? initialInput.file : undefined,
-      jobDescriptionText: initialInput?.mode === "text" ? initialInput.text : "",
+      jobDescriptionFile:
+        initialInput?.mode === "pdf" ? initialInput.file : undefined,
+      jobDescriptionText:
+        initialInput?.mode === "text" ? initialInput.text : "",
     });
   }, [initialInput, form]);
 
@@ -107,16 +112,21 @@ function UploadJobDescriptionCard({
   };
 
   const isSubmitDisabled =
-    mode === "pdf" ? !isPdfSelectionValid : jobDescriptionText.trim().length === 0;
+    mode === "pdf"
+      ? !isPdfSelectionValid
+      : jobDescriptionText.trim().length === 0;
 
   return (
     <Card className="mt-6 gap-0 px-2 border-slate-200 bg-white">
       <CardHeader>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <CardTitle className="text-2xl text-slate-900">Last opp stillingsbeskrivelse</CardTitle>
+            <CardTitle className="text-2xl text-slate-900">
+              Last opp stillingsbeskrivelse
+            </CardTitle>
             <CardDescription className="text-base text-slate-500">
-              Last opp PDF eller lim inn stillingsbeskrivelsen for å starte skanningsprosessen.
+              Last opp PDF eller lim inn stillingsbeskrivelsen for å starte
+              skanningsprosessen.
             </CardDescription>
           </div>
 
@@ -125,7 +135,11 @@ function UploadJobDescriptionCard({
               type="button"
               size="sm"
               variant={mode === "pdf" ? "default" : "outline"}
-              className={mode === "pdf" ? "bg-primary hover:bg-primary/80" : "border-slate-300 bg-white hover:bg-slate-100"}
+              className={
+                mode === "pdf"
+                  ? "bg-primary hover:bg-primary/80"
+                  : "border-slate-300 bg-white hover:bg-slate-100"
+              }
               onClick={() => setMode("pdf")}
             >
               PDF
@@ -134,7 +148,11 @@ function UploadJobDescriptionCard({
               type="button"
               size="sm"
               variant={mode === "text" ? "default" : "outline"}
-              className={mode === "text" ? "bg-primary hover:bg-primary/80" : "border-slate-300 bg-white hover:bg-slate-100"}
+              className={
+                mode === "text"
+                  ? "bg-primary hover:bg-primary/80"
+                  : "border-slate-300 bg-white hover:bg-slate-100"
+              }
               onClick={() => setMode("text")}
             >
               Tekst
@@ -168,7 +186,9 @@ function UploadJobDescriptionCard({
                     className="sr-only"
                     tabIndex={-1}
                     aria-invalid={fieldState.invalid}
-                    aria-describedby={fieldState.invalid ? fileErrorId : undefined}
+                    aria-describedby={
+                      fieldState.invalid ? fileErrorId : undefined
+                    }
                     onChange={(event) => {
                       const file = event.target.files?.[0];
                       setPickedFile(file);
@@ -185,7 +205,9 @@ function UploadJobDescriptionCard({
                           <FileTextIcon className="h-4 w-4 text-primary" />
                           {selectedFile?.name}
                         </p>
-                        <p className="mt-2 text-xs text-slate-500">{formatBytes(selectedFile?.size ?? 0)}</p>
+                        <p className="mt-2 text-xs text-slate-500">
+                          {formatBytes(selectedFile?.size ?? 0)}
+                        </p>
                         <Button
                           variant="ghost"
                           type="button"
@@ -209,13 +231,20 @@ function UploadJobDescriptionCard({
                     )}
                   </div>
 
-                  {!fieldState.invalid && <FieldDescription className="mt-2">Kun PDF-filer er tillatt</FieldDescription>}
+                  {!fieldState.invalid && (
+                    <FieldDescription className="mt-2">
+                      Kun PDF-filer er tillatt
+                    </FieldDescription>
+                  )}
 
                   {fieldState.invalid && (
                     <div id={fileErrorId}>
-                      <FieldError errors={[fieldState.error]} className="mt-3" />
+                      <FieldError
+                        errors={[fieldState.error]}
+                        className="mt-3"
+                      />
                     </div>
-                  ) }
+                  )}
                 </Field>
               )}
             />
@@ -225,7 +254,9 @@ function UploadJobDescriptionCard({
               control={form.control}
               render={({ field, fieldState }) => (
                 <Field data-invalid={fieldState.invalid}>
-                  <Label htmlFor={textAreaId}>Stillingsbeskrivelse (tekst)</Label>
+                  <Label htmlFor={textAreaId}>
+                    Stillingsbeskrivelse (tekst)
+                  </Label>
                   <Textarea
                     {...field}
                     id={textAreaId}
@@ -233,7 +264,9 @@ function UploadJobDescriptionCard({
                     placeholder="Lim inn stillingsbeskrivelsen her..."
                     maxLength={MAX_JOB_DESCRIPTION_TEXT_LENGTH}
                     aria-invalid={fieldState.invalid}
-                    aria-describedby={fieldState.invalid ? textErrorId : undefined}
+                    aria-describedby={
+                      fieldState.invalid ? textErrorId : undefined
+                    }
                   />
                   <FieldDescription>
                     Lim inn hele stillingsbeskrivelsen. Minst 40 tegn, maks{" "}
@@ -242,7 +275,10 @@ function UploadJobDescriptionCard({
 
                   {fieldState.invalid && (
                     <div id={textErrorId}>
-                      <FieldError errors={[fieldState.error]} className="mt-1" />
+                      <FieldError
+                        errors={[fieldState.error]}
+                        className="mt-1"
+                      />
                     </div>
                   )}
                 </Field>
@@ -251,28 +287,21 @@ function UploadJobDescriptionCard({
           )}
 
           <div className="mt-6 flex justify-end gap-3">
+            <Link to="/">
+              <Button
+                type="button"
+                variant="outline"
+                className="border-slate-300 bg-white hover:bg-slate-100 hover:text-black"
+                asChild
+              >
+                <span>Avbryt</span>
+              </Button>
+            </Link>
             <Button
-              type="button"
-              variant="outline"
-              className="border-slate-300 bg-white hover:bg-slate-100"
-              onClick={() => {
-                setPickedFile(undefined);
-                form.setValue("jobDescriptionText", "", {
-                  shouldDirty: true,
-                  shouldTouch: false,
-                  shouldValidate: false,
-                });
-                form.setValue("mode", "pdf", {
-                  shouldDirty: true,
-                  shouldTouch: false,
-                  shouldValidate: false,
-                });
-                onCancel();
-              }}
+              type="submit"
+              className="bg-primary hover:bg-primary/80"
+              disabled={isSubmitDisabled}
             >
-              Avbryt
-            </Button>
-            <Button type="submit" className="bg-primary hover:bg-primary/80" disabled={isSubmitDisabled}>
               {showRetryLabel ? "Prøv igjen" : "Neste"}
             </Button>
           </div>

--- a/frontend/src/pages/CVDatabase.tsx
+++ b/frontend/src/pages/CVDatabase.tsx
@@ -1,7 +1,6 @@
 import { useFetchCandidates } from "@/hooks/useFetchCandidates";
 import { useState } from "react";
 import PdfPreviewOverlay from "../components/PdfPreviewOverlay";
-import { AddNewCVModal } from "@/components/addNewCv/AddNewCVModal";
 import { Spinner } from "@/components/ui/spinner";
 import type { CandidatePreview } from "@/types/candidate";
 import ErrorBox from "@/components/ErrorBox";
@@ -10,6 +9,7 @@ import Searchbar from "@/components/Searchbar";
 import CandidateTable from "@/components/CVDatabase/CandidateTable";
 import HeaderSection from "@/components/HeaderSection";
 import CheckMarkPopUp from "@/components/CheckMarkPopUp";
+import { AddNewCVModal } from "@/components/addNewCv/AddNewCVModal";
 
 function CVDatabase() {
   const [reloadKey, setReloadKey] = useState(0);

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -21,7 +21,7 @@ function Home() {
         <HeaderSection
           header={"Velkommen tilbake!"}
           subsection={
-            "Her kan du se oversikten over de siste 5 skanningene gjennomført, administrere kandidatene eller starte ny skanning"
+            "Her kan du se oversikten over de siste skanningene gjennomført, administrere kandidatene eller starte ny skanning"
           }
         />
 

--- a/frontend/src/pages/NewScreeningPage.tsx
+++ b/frontend/src/pages/NewScreeningPage.tsx
@@ -1,6 +1,6 @@
 import { saveScreeningRun } from "@/api/fetchScreenings";
 import { runScreeningWithGemini } from "@/api/runScreeningWithGemini";
-import NewScreening from "@/components/newScreening/NewScreening";
+import NewScreening from "@/components/NewScreening/NewScreening";
 import type { JobDescriptionInput } from "@/validations/UploadJobDescriptionSchema";
 import type { StepStatus } from "@/types/newScreeningTypes";
 import { useState } from "react";

--- a/frontend/src/pages/ScreeningHistory.tsx
+++ b/frontend/src/pages/ScreeningHistory.tsx
@@ -102,7 +102,7 @@ function ScreeningHistory() {
                       </h3>
                       <div className="mt-2 flex items-center space-x-4 text-sm text-(--color-dark) opacity-75">
                         <span className="flex items-center">
-                          <Clock className="h-4 w-4" aria-hidden="true" />
+                          <Clock className="h-4 w-4 m-1" aria-hidden="true" />
                           <span>{formatDate(screening.screenedAt)}</span>
                         </span>
                       </div>

--- a/frontend/src/types/newScreeningTypes.ts
+++ b/frontend/src/types/newScreeningTypes.ts
@@ -2,6 +2,7 @@ export type ScreeningView = "upload" | "processing" | "results" | "candidate";
 
 export type StepStatus = "active" | "completed" | "upcoming";
 
+// This is the type that is read from the CVs of the candidates.
 export type ScreeningCandidate = {
   id: number;
   rank: number;

--- a/frontend/src/types/screening.ts
+++ b/frontend/src/types/screening.ts
@@ -6,6 +6,7 @@ export type ScreeningDetails = {
   candidates: Array<RankedCandidate>;
 };
 
+
 export type RankedCandidate = {
   candidateId: number;
   candidateName: string;

--- a/frontend/src/types/screening.ts
+++ b/frontend/src/types/screening.ts
@@ -17,7 +17,8 @@ export type RankedCandidate = {
   unknowns: string[];
   summary?: string;
   createdAt: string;
-  aml?: "4.6" | "4.7";
+  aml46?: boolean,
+  aml47?: boolean,
 };
 
 export type SaveScreeningRunPayload = {


### PR DESCRIPTION
Check that this pr fix: 

1.  The bug that makes short lists get weird styling in home page, such as this

<img width="1702" height="1230" alt="Image" src="https://github.com/user-attachments/assets/20afa06f-108e-4ba0-b60c-abd32f0663ed" />

2. The bug that makes all candidates appear in both lists in scanning sidebar if there are bot qualified and unqualified candidates.

<img width="375" height="311" alt="Image" src="https://github.com/user-attachments/assets/c3b837db-2079-4450-b4bb-5424932e9530" />

3. Make cancel button in new screening return to home: 

<img width="1080" height="1920" alt="Image" src="https://github.com/user-attachments/assets/da0de3e1-9728-4723-bc05-3bc10472ef38" />

4. Sidebar does not have scrollers unless necessary