### PR TITLE
[Bug] Screening should now fail if not enough candidates are in output (#123)

### DIFF
--- a/backend/src/services/screening/runScreening.ts
+++ b/backend/src/services/screening/runScreening.ts
@@ -70,6 +70,12 @@ export async function runScreeningService({
       );
     }
 
+    if (candidates.length < candidatesWithCv.length) {
+      throw new Error(
+        `Screening feilet: For få kandidater i output (${candidates.length}/${candidatesWithCv.length}).`,
+      );
+    }
+
     const screeningRecord = buildScreeningRecord({
       jobDescriptionInput,
       jobDescriptionText,
@@ -122,6 +128,12 @@ export async function runScreeningService({
   if (!candidates.length) {
     throw new Error(
       "Fant ingen kandidater som kunne matches mot screeningresultatet.",
+    );
+  }
+
+  if (candidates.length < candidatesWithCv.length) {
+    throw new Error(
+      `Screening feilet: For få kandidater i output (${candidates.length}/${candidatesWithCv.length}).`,
     );
   }
 


### PR DESCRIPTION
To test this, check with around 10 candidates and norllm model (this usually causes it to not return enough candidates) and check that the logging in the backend console returns that screening failed because of too few candidates.
Also check that normal functionality is preserved